### PR TITLE
Update buildWinDistributions.bat

### DIFF
--- a/buildWinDistributions.bat
+++ b/buildWinDistributions.bat
@@ -8,7 +8,7 @@ python setup.py install
 
 del C:\Python27\Lib\site-packages\psychopy.pth
 xcopy /I /Y psychopy\*.txt C:\Python27
-copy /I /Y C:\Windows\System32\avbin.dll avbin.dll
+copy /Y C:\Windows\System32\avbin.dll avbin.dll
 rem build the installer
 makensis.exe /v3 buildCompleteInstaller.nsi
 


### PR DESCRIPTION
The copy command fails with a syntax failure because /I is not a valid parameter. Probably this line remained while the command was changed to copy from xcopy...
